### PR TITLE
v0.2

### DIFF
--- a/func.R
+++ b/func.R
@@ -1,0 +1,82 @@
+# 関数いろいろ
+
+requireLibs <- function(libs) {
+  for(lib in libs){
+    if(!require(lib, character.only = T)){
+      install.packages(lib)
+      require(lib, character.only = T)
+    }
+  }
+}
+
+# nullチェック
+getVal <- function(obj){
+  if(is.null(obj) || is.na(obj)){
+    return("")
+  }else{
+    return(obj)
+  }
+}
+
+# 雑にチェック
+validateData <- function(tbl){
+  ret <- data.frame(
+    is_error = F,
+    message = ""
+  )
+  
+  if(is.null(tbl)){
+    ret$is_error = T
+    ret$message = "データが空です。"
+  }else if(is.na(tbl)){
+    ret$is_error = T
+    ret$message = "エラーで取得できなかったみたい。"
+  }else if(nrow(tbl)==0){
+    ret$is_error = T
+    ret$message = "0件です。"
+  }
+  
+  return(ret)
+}
+
+
+######
+# 拡張する場合は変更するとこ
+######
+
+# slackから受け取ったjsonを１メッセージごとに処理するとこ
+json2row <- function(message){
+  dat <- 
+    c(getVal(message$type),
+      getVal(message$user),
+      getVal(message$text),
+      format(
+        as.POSIXct(as.numeric(message$ts), origin="1970-01-01"),
+        "%Y/%m/%d"
+      ),
+      format(
+        as.POSIXct(as.numeric(message$ts), origin="1970-01-01"),
+        "%H:%M:%S"
+      ))
+  names(dat) <- c("type", "user", "text", "年月日", "時分秒")
+  
+  dat
+}
+
+# slackから受け取ったjsonを処理するとこ
+makeData <- function(jsonFromSlack){
+  ret <- NA
+  if(is.list(jsonFromSlack[["messages"]])){
+    json <- jsonFromSlack[["messages"]]
+    
+    ret <- do.call(rbind,
+                   lapply(json,json2row)
+    ) 
+    if(!is.null(ret) && !is.na(ret)){
+      ret <- ret %>% as.data.frame
+    }else{
+      ret <- NA
+    }
+  }
+  return(ret)
+}

--- a/func.R
+++ b/func.R
@@ -1,3 +1,5 @@
+source("json2row.R")
+
 # 関数いろいろ
 
 requireLibs <- function(libs) {
@@ -40,7 +42,7 @@ validateData <- function(tbl){
 }
 
 # slackから受け取ったjsonを処理するとこ
-makeData <- function(jsonFromSlack){
+makeData <- function(jsonFromSlack, json2row){
   ret <- NA
   if(is.list(jsonFromSlack[["messages"]])){
     json <- jsonFromSlack[["messages"]]
@@ -58,25 +60,4 @@ makeData <- function(jsonFromSlack){
 }
 
 
-# slackから受け取ったjsonを１メッセージごとに処理するとこ
-json2row <- function(message){
-  dat <- 
-    c(getVal(message$type),
-      getVal(message$user),
-      getVal(message$text),
-      format(
-        as.POSIXct(as.numeric(message$ts), origin="1970-01-01"),
-        "%Y/%m/%d"
-      ),
-      format(
-        as.POSIXct(as.numeric(message$ts), origin="1970-01-01"),
-        "%H:%M:%S"
-      ))
-  dat <- c(dat,dat[3])
-  names(dat) <- c("type", "user", "text", "年月日", "時分秒", "search")
-  
-  dat
-}
-
-if(file.exists("json2row.R")) source("json2row.R")
 

--- a/func.R
+++ b/func.R
@@ -30,37 +30,13 @@ validateData <- function(tbl){
     ret$message = "データが空です。"
   }else if(is.na(tbl)){
     ret$is_error = T
-    ret$message = "エラーで取得できなかったみたい。"
+    ret$message = "0件です。"
   }else if(nrow(tbl)==0){
     ret$is_error = T
     ret$message = "0件です。"
   }
   
   return(ret)
-}
-
-
-######
-# 拡張する場合は変更するとこ
-######
-
-# slackから受け取ったjsonを１メッセージごとに処理するとこ
-json2row <- function(message){
-  dat <- 
-    c(getVal(message$type),
-      getVal(message$user),
-      getVal(message$text),
-      format(
-        as.POSIXct(as.numeric(message$ts), origin="1970-01-01"),
-        "%Y/%m/%d"
-      ),
-      format(
-        as.POSIXct(as.numeric(message$ts), origin="1970-01-01"),
-        "%H:%M:%S"
-      ))
-  names(dat) <- c("type", "user", "text", "年月日", "時分秒")
-  
-  dat
 }
 
 # slackから受け取ったjsonを処理するとこ
@@ -80,3 +56,27 @@ makeData <- function(jsonFromSlack){
   }
   return(ret)
 }
+
+
+# slackから受け取ったjsonを１メッセージごとに処理するとこ
+json2row <- function(message){
+  dat <- 
+    c(getVal(message$type),
+      getVal(message$user),
+      getVal(message$text),
+      format(
+        as.POSIXct(as.numeric(message$ts), origin="1970-01-01"),
+        "%Y/%m/%d"
+      ),
+      format(
+        as.POSIXct(as.numeric(message$ts), origin="1970-01-01"),
+        "%H:%M:%S"
+      ))
+  dat <- c(dat,dat[3])
+  names(dat) <- c("type", "user", "text", "年月日", "時分秒", "search")
+  
+  dat
+}
+
+if(file.exists("json2row.R")) source("json2row.R")
+

--- a/json2row.R
+++ b/json2row.R
@@ -1,0 +1,48 @@
+# slackから受け取ったjsonを１メッセージごとに処理するとこ
+json2row.default <- function(message){
+  dat <- 
+    c(getVal(message$type),
+      getVal(message$user),
+      getVal(message$text),
+      format(
+        as.POSIXct(as.numeric(message$ts), origin="1970-01-01"),
+        "%Y/%m/%d"
+      ),
+      format(
+        as.POSIXct(as.numeric(message$ts), origin="1970-01-01"),
+        "%H:%M:%S"
+      ))
+  dat <- c(dat,dat[3])
+  names(dat) <- c("type", "user", "text", "年月日", "時分秒", "search")
+  
+  dat
+}
+
+
+######
+# 拡張する場合は変更するとこ
+######
+
+json2row.custom <- function(message){
+  if(getVal(message$subtype) != "bot_message"){
+    return(NA)
+  }
+  dat <-
+    c(getVal(message$type),
+      getVal(lapply(message$attachments[[1]]$fields,function(l){if(l$title=="企業名"){l$value}}) %>% unlist),
+      getVal(lapply(message$attachments[[1]]$fields,function(l){if(l$title=="画面名"){l$value}}) %>% unlist),
+      getVal(message$attachments[[1]]$pretext),
+      format(
+        as.POSIXct(as.numeric(message$ts), origin="1970-01-01"),
+        "%Y/%m/%d"
+      ),
+      format(
+        as.POSIXct(as.numeric(message$ts), origin="1970-01-01"),
+        "%H:%M:%S"
+      ))
+  dat <- c(dat, paste(dat[2],dat[3],dat[4],sep=" "))
+  names(dat) <- c("type", "user", "page", "text", "年月日", "時分秒", "search")
+  
+  dat
+}
+

--- a/server.R
+++ b/server.R
@@ -1,0 +1,183 @@
+source("func.R")
+
+requireLibs(c("shiny","httr","magrittr"))
+
+# Define server logic required to draw a histogram
+shinyServer(function(input, output, session) {
+  # init
+  endPoint.history <- 'https://slack.com/api/channels.history'
+  endPoint.user <- "https://slack.com/api/users.list"
+  
+  # slackへの送信パラメータ
+  getParams <- reactive({
+    oldest = as.numeric(as.POSIXct(as.Date(input$date_range[1])))
+    latest = as.numeric(as.POSIXct(as.Date(input$date_range[2])))
+    token = input$token
+    channel = input$channel
+    
+    params <- list(
+      token = getVal(token),
+      channel = getVal(channel),
+      count = 200,
+      latest = latest,
+      oldest = oldest
+    )
+    params
+  })
+  
+  # トークンTextBoxの生成
+  output$tokenOut <- renderUI({
+    urlInfo <- parseQueryString(session$clientData$url_search)
+    
+    textInput('token',"トークン", urlInfo[["token"]])
+  })
+  
+  # チェンネルIDのTextBoxの生成
+  output$channelOut <- renderUI({
+    urlInfo <- parseQueryString(session$clientData$url_search)
+    
+    textInput('channel',"チェンネルID", urlInfo[["channel"]])
+  })
+  
+  # コピペ用URLのInputBox
+  output$urlOut <- renderUI({
+    cdata <- session$clientData
+    
+    textInput('url',
+              "url", 
+              paste0(
+                cdata$url_protocol,
+                "//",
+                cdata$url_hostname,
+                ":",
+                cdata$url_port,
+                cdata$url_pathname,
+                "?token=",
+                input$token,
+                "&channel=",
+                input$channel
+              )
+    )
+  })
+  
+  # slackからの応答処理
+  getSlackData <- reactive({
+    params <- getParams()
+    
+    if(is.na(params$token) || is.na(params$channel) || 
+       is.null(params$token) || is.null(params$channel) || 
+       length(params$token) == 0 || length(params$channel) == 0){
+      return(NA)
+    }
+    
+    resp <- POST(endPoint.history, 
+                body = params,
+                encode = "multipart",
+                content_type = "application/x-www-form-urlencoded"
+#                ,verbose()
+                )
+    jsonFromSlack <- content(resp, "parsed")
+    
+    makeData(jsonFromSlack)
+  })
+  
+  # グラフタブ
+  ## 全体の集計グラフ
+  output$graph_all <- renderPlot({
+    tbl <- getSlackData()
+    save(tbl, file="tbl.obj")
+    
+    check <- validateData(tbl)
+    
+    if(check$is_error){
+      return(check$message)
+    }
+    
+    pie(table(tbl[,"user"]))
+  })
+  
+  ## 全体の集計
+  output$table_all <- renderTable({
+    tbl <- getSlackData()
+    
+    check <- validateData(tbl)
+    
+    if(check$is_error){
+      return(check$message)
+    }
+    
+    ret <- as.data.frame(table(tbl[,"user"]))
+    names(ret)<- c("key","count")
+    
+    rbind(ret,data.frame(key = "合計", count = sum(ret$count) ))
+  })
+  
+  ## 絞り込みの集計グラフ
+  output$graph_filterd <- renderPlot({
+    tbl <- getSlackData()
+    
+    check <- validateData(tbl)
+    
+    if(check$is_error){
+      return(check$message)
+    }
+    
+    filter <- grep(pattern = input$refine, tbl[,"text"])
+    if(sum(filter)==0){
+      return("0件です。")
+    }
+    
+    pie(table(tbl[filter,"user"]))
+  })
+  
+  ## 絞り込みの集計表
+  output$table_filterd <- renderTable({
+    tbl <- getSlackData()
+    
+    check <- validateData(tbl)
+    if(check$is_error){
+      return(check$message)
+    }
+    
+    filter <- grep(pattern = input$refine, tbl[,"text"])
+    if(sum(filter)==0){
+      return("0件です。")
+    }
+    
+    ret <- as.data.frame(table(tbl[filter,"user"]))
+    names(ret)<- c("key","count")
+    
+    rbind(ret,data.frame(key = "合計", count = sum(ret$count) ))
+    
+  })
+  
+  # 一覧表タブ
+  output$list <- renderTable({
+    tbl <- getSlackData()
+    
+    check <- validateData(tbl)
+    
+    if(check$is_error){
+      return(check$message)
+    }
+    
+    filter <- grep(pattern = input$refine, tbl[,"text"])
+    ret <- tbl[filter,]
+
+    ret
+  })
+  
+  # CSVタブ
+  output$csv <- renderText({
+    tbl <- getSlackData()
+    
+    check <- validateData(tbl)
+    
+    if(check$is_error){
+      return(check$message)
+    }
+    
+    paste("CSVダウンロードボタンつくる？")
+  })
+  
+})

--- a/server.R
+++ b/server.R
@@ -1,6 +1,8 @@
 source("func.R")
 
-requireLibs(c("shiny","httr","magrittr","ggplot2"))
+library("shiny")
+library("httr")
+library("magrittr")
 
 shinyServer(function(input, output, session) {
   # init
@@ -77,7 +79,8 @@ shinyServer(function(input, output, session) {
                 )
     jsonFromSlack <- content(resp, "parsed")
     
-    makeData(jsonFromSlack)
+    json2row <- ifelse(input$chk_custom, json2row.custom, json2row.defult)
+    makeData(jsonFromSlack, json2row)
   })
   
   # グラフタブ
@@ -101,8 +104,7 @@ shinyServer(function(input, output, session) {
   ## 全体の集計グラフ
   output$graph_all <- renderPlot({
     tbl <- getSlackData()
-    save(tbl, file="tbl.obj")
-    
+
     check <- validateData(tbl)
     
     if(check$is_error){

--- a/ui.R
+++ b/ui.R
@@ -1,13 +1,12 @@
 
 requireLibs("shiny")
 
-# Define UI for application that draws a histogram
 shinyUI(fluidPage(
   
   # Application title
   titlePanel("Slackからログとってくるツール"),
   
-  # Sidebar with a slider input for number of bins 
+  # Sidebar 
   sidebarLayout(
     sidebarPanel(
       dateRangeInput(
@@ -18,14 +17,14 @@ shinyUI(fluidPage(
       ),
       textInput('refine',"絞込ワード"),
       hr(),
-      tags$p("接続先設定"),
+      tags$p("↓接続先設定↓"),
       hr(),
       uiOutput('tokenOut'),
       uiOutput('channelOut'),
       uiOutput('urlOut')
     ),
     
-    # Show a plot of the generated distribution
+    # MainPanel
     mainPanel(
        tabsetPanel(
          tabPanel("Plot",

--- a/ui.R
+++ b/ui.R
@@ -1,5 +1,5 @@
 
-requireLibs("shiny")
+library("shiny")
 
 shinyUI(fluidPage(
   
@@ -16,6 +16,7 @@ shinyUI(fluidPage(
         end = format(Sys.Date(), "%Y-%m-%d")
       ),
       textInput('refine',"絞込ワード"),
+      checkboxInput('chk_custom', "仮：カスタムフィルタ", value = T),
       hr(),
       tags$p("↓接続先設定↓"),
       hr(),

--- a/ui.R
+++ b/ui.R
@@ -1,0 +1,46 @@
+
+requireLibs("shiny")
+
+# Define UI for application that draws a histogram
+shinyUI(fluidPage(
+  
+  # Application title
+  titlePanel("Slackからログとってくるツール"),
+  
+  # Sidebar with a slider input for number of bins 
+  sidebarLayout(
+    sidebarPanel(
+      dateRangeInput(
+        "date_range",
+        "範囲選択",
+        start = format(Sys.Date()-1, "%Y-%m-%d"),
+        end = format(Sys.Date(), "%Y-%m-%d")
+      ),
+      textInput('refine',"絞込ワード"),
+      hr(),
+      tags$p("接続先設定"),
+      hr(),
+      uiOutput('tokenOut'),
+      uiOutput('channelOut'),
+      uiOutput('urlOut')
+    ),
+    
+    # Show a plot of the generated distribution
+    mainPanel(
+       tabsetPanel(
+         tabPanel("Plot",
+                  fluidRow(
+                    column(12, h3("絞り込み")),
+                    column(6, tableOutput("table_filterd")),
+                    column(6, plotOutput("graph_filterd")),
+                    column(12, h3("全体")),
+                    column(6, tableOutput("table_all")),
+                    column(6, plotOutput("graph_all"))
+                  )
+         ),
+         tabPanel("List", tableOutput("list")),
+         tabPanel("CSV", verbatimTextOutput("csv"))
+       )
+    )
+  )
+))


### PR DESCRIPTION
トークン、チェンネルIDを入力するとSlackのチャンネルログを取ってくる。
絞り込みワードを入れると、ログを絞りこめる。
json形式が特殊な場合に、フィルタを噛ませて表示できるようにした。
全体的にだいぶ雑。
汎用性があるようでない。